### PR TITLE
Honor the starting index of Ordered Lists

### DIFF
--- a/Sources/Markdownosaur/Markdownosaur.swift
+++ b/Sources/Markdownosaur/Markdownosaur.swift
@@ -206,7 +206,7 @@ public struct Markdownosaur: MarkupVisitor {
       // Grab the highest number to be displayed and measure its width (yes normally some digits are wider than others but since we're using the numeral mono font all will be the same width in this case)
       // Respect the list's original starting index as provided by the Markdown parser.
       let startIndex = Int(orderedList.startIndex)
-        let highestNumberInList = startIndex + orderedList.childCount - 1
+      let highestNumberInList = startIndex + orderedList.childCount - 1
       let numeralColumnWidth = ceil(NSAttributedString(string: "\(highestNumberInList).", attributes: [.font: monospacedDigitFont]).size().width)
       
       let spacingFromIndex: CGFloat = 5.0

--- a/Sources/Markdownosaur/Markdownosaur.swift
+++ b/Sources/Markdownosaur/Markdownosaur.swift
@@ -204,7 +204,9 @@ public struct Markdownosaur: MarkupVisitor {
       let leftMarginOffset = baseLeftMargin + (20.0 * CGFloat(orderedList.listDepth))
       
       // Grab the highest number to be displayed and measure its width (yes normally some digits are wider than others but since we're using the numeral mono font all will be the same width in this case)
-      let highestNumberInList = orderedList.childCount
+      // Respect the list's original starting index as provided by the Markdown parser.
+      let startIndex = Int(orderedList.startIndex)
+        let highestNumberInList = startIndex + orderedList.childCount - 1
       let numeralColumnWidth = ceil(NSAttributedString(string: "\(highestNumberInList).", attributes: [.font: monospacedDigitFont]).size().width)
       
       let spacingFromIndex: CGFloat = 5.0
@@ -229,7 +231,9 @@ public struct Markdownosaur: MarkupVisitor {
       var numberAttributes = listItemAttributes
       numberAttributes[.font] = monospacedDigitFont
       
-      let numberAttributedString = NSAttributedString(string: "\t\(index + 1).\t", attributes: numberAttributes)
+      // Use the original starting index from the parser rather than re-indexing from 1.
+      let displayNumber = startIndex + index
+      let numberAttributedString = NSAttributedString(string: "\t\(displayNumber).\t", attributes: numberAttributes)
       listItemAttributedString.insert(numberAttributedString, at: 0)
       
       result.append(listItemAttributedString)


### PR DESCRIPTION
AI's often return Markdown with blank lines between Ordered Lists, such as this:

```
Here are focused blog-post ideas about black holes, with quick angles and pros/cons so you can pick one fast.

1) "How Black Holes Grow: From Seeds to Giants" 
- Angle: Explain formation (stellar collapse, direct collapse, mergers), accretion, and observational evidence.
- Pros ✓: High curiosity; connects to galaxy evolution; evergreen.
- Cons ✗: Requires careful explanation of technical processes.

2) "A Beginner's Guide to Event Horizons and Singularity"
- Angle: Intuitive metaphors for event horizon, what a singularity means (and what we don't know).
- Pros ✓: Accessible; great for wide audience; shareable.
- Cons ✗: Risk of oversimplifying hard concepts.

3) "What the First Black Hole Image Taught Us"
- Angle: Walk through the Event Horizon Telescope results, methods, and implications.
- Pros ✓: Ties to a clear milestone; rich visuals; authoritative.
- Cons ✗: Slightly time-bound; needs accurate citations.
```

The 'visitOrderedList` was implicitly using '0' as the starting point for counting, and because each of these is registered as a separate ordered list, it was numbering them as `1. .... 1. .... 1. ....`

This update reads the `orderedList.startIndex` as the starting point